### PR TITLE
Fix environment variable retrieval

### DIFF
--- a/passive-aggression.py
+++ b/passive-aggression.py
@@ -31,16 +31,8 @@ import lib.passive as passive
 import lib.printer as p
 
 # check for creds in env vars
-
-if environ['PT_USER']:
-    username = environ['PT_USER']
-else:
-    username = None
-
-if environ['PT_API_KEY']:
-    api_key = environ['PT_API_KEY']
-else:
-    api_key = None
+api_key = environ.get('PT_API_KEY')
+username = environ.get('PT_USER')
 
 
 def check_resp_for_errors(loaded_content, sp):


### PR DESCRIPTION
This fixes how environment variables are retrieved. Previously if the variable was not set, Python would throw a `KeyError` as follows:

```
Traceback (most recent call last):
  File "passive-aggression.py", line 35, in <module>
    if environ['PT_USER']:
  File "/usr/lib64/python2.7/UserDict.py", line 40, in __getitem__
    raise KeyError(key)
KeyError: 'PT_USER'
```

Testing steps:
 - [ ] Unset the PT_* environment variables
 - [ ] Run the passive-aggression script and **do not** get a stack trace